### PR TITLE
Correct access key ID env var in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Set the following environment variables
 ```shell
 export DOMAIN=<the domain you want a certificate for>
 export EMAIL=<the email associated with the certificate>
-export AWS_ACCCESS_KEY_ID=<aws access key for route53>
+export AWS_ACCESS_KEY_ID=<aws access key for route53>
 export AWS_SECRET_ACCESS_KEY=<aws secret key for route53>
 ```
 


### PR DESCRIPTION
Corrects misspelling of `AWS_ACCESS_KEY_ID` in the Readme.